### PR TITLE
feat: add `below` parameter to section functions

### DIFF
--- a/src/lavandula.typ
+++ b/src/lavandula.typ
@@ -170,18 +170,18 @@
   )
 }
 
-#let section(title: "", body) = {
-  block(width: 100%, below: 3.5em)[
+#let section(title: "", below: 3.5em, body) = {
+  block(width: 100%, below: below)[
     == #title
     #block(inset: (x: 0.5pt), width: 100%, body)
   ]
 }
 
-#let section-element(title: "", info: "", body) = {
+#let section-element(title: "", info: "", below: 1.7em, body) = {
   block(
     inset: (top: 3pt),
     width: 100%,
-    below: 1.7em,
+    below: below,
     grid(
       columns: (auto, 1fr),
       rows: auto,
@@ -197,11 +197,11 @@
   )
 }
 
-#let section-element-advanced(title: "", info-top-right: "", info-top-left: "", icon: "", body) = {
+#let section-element-advanced(title: "", info-top-right: "", info-top-left: "", icon: "", below: 1.7em, body) = {
   block(
     inset: (top: 3pt),
     width: 100%,
-    below: 1.7em,
+    below: below,
     grid(
       columns: (15pt, auto, 1fr),
       rows: auto,


### PR DESCRIPTION
## Summary

- Added optional `below` parameter to `section`, `section-element`, and `section-element-advanced`
- Default values are preserved (`3.5em` / `1.7em`), so existing usage is fully backwards-compatible
- Allows callers to control inter-block spacing without overriding the functions entirely

## Motivation

When fitting a CV to a single page, the only way to adjust spacing between sections/elements was to redefine the entire function in the document. A simple named parameter makes this a one-liner at the call site.

## Example

```typst
#section(title: "Experience", below: 1.1em)[
  #section-element(title: "Job Title", below: 1em, info: [_2024_])[
    ...
  ]
]
```